### PR TITLE
Option to set ember build environment when packaging

### DIFF
--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -20,7 +20,7 @@ module.exports = {
     availableOptions: [{
         name: 'environment',
         type: String,
-        default: 'development',
+        default: 'production',
         aliases: ['e', {
             dev: 'development'
         }, {
@@ -128,7 +128,7 @@ module.exports = {
         aliases: []
     }],
 
-    build: function () {
+    build: function (options) {
         this.ui.startProgress(chalk.green('Building'), chalk.green('.'));
 
         var buildTask = new this.tasks.Build({
@@ -138,7 +138,7 @@ module.exports = {
         });
 
         return buildTask.run({
-            environment: 'production',
+            environment: options.environment,
             outputPath: './tmp/electron-build-tmp/dist'
         });
     },

--- a/tests/unit/commands/package-test.js
+++ b/tests/unit/commands/package-test.js
@@ -76,6 +76,38 @@ describe('ember electron:package command', () => {
         });
     });
 
+    it('should build for the appropriate environment', () => {
+        let testEnv = 'development';
+        let builtEnv = null;
+
+        commandOptions.environment = testEnv;
+        commandOptions.build = function (options) {
+            builtEnv = options.environment;
+            return RSVP.resolve();
+        };
+
+        let command = new CommandUnderTest(commandOptions).validateAndRun();
+
+        return expect(command).to.be.fulfilled.then(() => {
+            expect(builtEnv).to.equal(testEnv);
+        });
+    });
+
+    it('should build production environment by default', () => {
+        let builtEnv = null;
+
+        commandOptions.build = function (options) {
+            builtEnv = options.environment;
+            return RSVP.resolve();
+        };
+
+        let command = new CommandUnderTest(commandOptions).validateAndRun();
+
+        return expect(command).to.be.fulfilled.then(() => {
+            expect(builtEnv).to.equal('production');
+        });
+    });
+
     it('should not attempt packaging when the build fails', () => {
         let tasks = [];
 


### PR DESCRIPTION
Allows `ember electron:package --environment=X` to build the package with `environment` set to `X`.  Currently it is hardcoded to `production`:
https://github.com/felixrieseberg/ember-electron/blob/master/lib/commands/package.js#L141