### PR TITLE
Package command: ensure target exists

### DIFF
--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -263,6 +263,7 @@ module.exports = {
                 return reject();
             }
 
+            fs.ensureDirSync(target);
             this.ui.writeLine(`Installing Electron headers for version ${electronVersion}`);
             rebuild.installNodeHeaders(`v${electronVersion}`, undefined, undefined, arch)
                 .then(() => {


### PR DESCRIPTION
Packaging on OS X failed silently for me without ensuring that the target exists.

I hope this is the right solution to this problem!