### PR TITLE
Manually add filesystem watches for subdirs of dist when running on l…

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -9,11 +9,27 @@
 
     // Reload the page when anything in `dist` changes
     const fs = window.requireNode('fs');
+    let watch = function(sub) {
+        let dirname = __dirname;
+        if (sub) { dirname += sub; }
+        fs.watch(dirname, {recursive: true}, function (e) {
+            window.location.reload()
+        });
+    }
     fs.stat(__dirname, function (err, stat) {
         if (!err) {
-            fs.watch(__dirname, {recursive: true}, function (e) {
-                window.location.reload()
-            });
+            watch();
+
+            // On linux, the recursive `watch` command is not fully supported:
+            // https://nodejs.org/docs/latest/api/fs.html#fs_fs_watch_filename_options_listener
+            //
+            // However, the recursive option WILL watch direct children of the
+            // given directory.  So, this hack just manually sets up watches on
+            // the expected subdirs -- that is, `assets` and `tests`.
+            if (process.platform === 'linux') {
+                watch('/assets');
+                watch('/tests');
+            }
         }
     });
 })();


### PR DESCRIPTION
…inux, because recursive fs.watch isn't fully supported

Fixes #47.