### PR TITLE
added optional dev dependency copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You can pass options to the packager by either putting configuration into your a
 * `--cache` - *String* The directory where prebuilt, pre-packaged Electron downloads are cached. Defaults to `$HOME/.electron`.
 * `--helper-bundle-id` - *String* The bundle identifier to use in the application helper's plist (OS X only).
 * `--extend-info` - *String* Filename of a plist file; the contents are added to the app's plist. Entries in `extend-info` override entries in the base plist file supplied by electron-prebuilt, but are overridden by other explicit arguments such as `app-version` or `app-bundle-id`.
+* `--copy-dev-modules` - *Boolean* Copy dependency node modules from local dev node_modules instead of installing them.
 * `--extra-resource` - *String* Filename of a file to be copied directly into the app's Contents/Resources directory.
 * `--icon` - *String* Currently you must look for conversion tools in order to supply an icon in the format required by the platform. If the file extension is omitted, it is auto-completed to the correct extension based on the platform.
 

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -209,6 +209,7 @@ module.exports = {
 
     copyDevModules: function(options) {
           return new Promise((resolve, reject) => {
+             const ee = this.project.pkg['ember-electron'] || {};
               if(options.copyDevModules || ee['copy-dev-modules']){
                 const modules_lentgh = this.modulesToCopy.length;
                 const target         = `${this.project.root}/tmp/electron-build-tmp/node_modules/`;

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -162,7 +162,7 @@ module.exports = {
             ui: this.ui,
             modulesToCopy: this.modulesToCopy,
             analytics: this.analytics,
-            project: this.project,
+            project: this.project
         });
 
         return buildTask.run({
@@ -208,34 +208,32 @@ module.exports = {
     },
 
     copyDevModules: function(options) {
-          return new Promise((resolve, reject) => {
-             const ee = this.project.pkg['ember-electron'] || {};
-              if(options.copyDevModules || ee['copy-dev-modules']){
-                const modules_lentgh = this.modulesToCopy.length;
+        return new Promise((resolve, reject) => {
+            const ee = this.project.pkg['ember-electron'] || {};
+            if (options.copyDevModules || ee['copy-dev-modules']) {
+                const modulesLentgh = this.modulesToCopy.length;
                 const target         = `${this.project.root}/tmp/electron-build-tmp/node_modules/`;
                 const root           = `${this.project.root}/node_modules/`;
 
-                if(modules_lentgh > 0) {
-                    for (var i = 0; i < modules_lentgh; i++) {
-                        try{
-                             this.ui.writeLine('Copying ' + this.modulesToCopy[i] + ' from dev node_modules');
-                             fs.copySync(root + this.modulesToCopy[i], target + this.modulesToCopy[i]);
+                if (modulesLentgh > 0) {
+                    for (var i = 0; i < modulesLentgh; i++) {
+                        try {
+                            this.ui.writeLine('Copying ' + this.modulesToCopy[i] + ' from dev node_modules');
+                            fs.copySync(root + this.modulesToCopy[i], target + this.modulesToCopy[i]);
                         } catch (err) {
-                             reject(err);
+                            reject(err);
                         }
                     }
                 }
-             }
-             resolve();
-         });
-
+            }
+            resolve();
+        });
     },
-
 
     installDependency: function (installedDeps, name, version) {
         return new Promise((resolve, reject) => {
             const path = `${this.project.root}/tmp/electron-build-tmp`;
-       
+
             npmi({name, version, path}, (err) => {
                 if (err) {
                     this.ui.writeLine('');
@@ -263,22 +261,21 @@ module.exports = {
             // Push all dependencies into an array for easier processing
             for (var name in this.project.pkg.dependencies) {
                 // Check if we need to copy dev node_modules
-                if(options.copyDevModules || ee['copy-dev-modules']){
-                        // check if dependencie is added in dev dependencies
-                        if (this.project.pkg.devDependencies.hasOwnProperty(name)) {
-                                this.modulesToCopy.push(name);
-                        } else {
-                            // not in dev dependencies, adding to install
-                             if (this.project.pkg.dependencies.hasOwnProperty(name)) {
-                                 deps.push([name, this.project.pkg.dependencies[name]]);
-                            }
+                if (options.copyDevModules || ee['copy-dev-modules']) {
+                    // check if dependencie is added in dev dependencies
+                    if (this.project.pkg.devDependencies.hasOwnProperty(name)) {
+                        this.modulesToCopy.push(name);
+                    } else {
+                        // not in dev dependencies, adding to install
+                        if (this.project.pkg.dependencies.hasOwnProperty(name)) {
+                            deps.push([name, this.project.pkg.dependencies[name]]);
                         }
+                    }
                 } else {
-                          if (this.project.pkg.dependencies.hasOwnProperty(name)) {
-                                 deps.push([name, this.project.pkg.dependencies[name]]);
-                            }
+                    if (this.project.pkg.dependencies.hasOwnProperty(name)) {
+                        deps.push([name, this.project.pkg.dependencies[name]]);
+                    }
                 }
-              
             }
 
             // Process the array in order

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -147,15 +147,22 @@ module.exports = {
         type: String,
         default: undefined,
         aliases: []
+    }, {
+        name: 'copy-dev-modules',
+        type: String,
+        default: undefined,
+        aliases: []
     }],
 
     build: function (options) {
         this.ui.startProgress(chalk.green('Building'), chalk.green('.'));
+        this.modulesToCopy = [];
 
         const buildTask = new this.tasks.Build({
             ui: this.ui,
+            modulesToCopy: this.modulesToCopy,
             analytics: this.analytics,
-            project: this.project
+            project: this.project,
         });
 
         return buildTask.run({
@@ -200,10 +207,34 @@ module.exports = {
         }
     },
 
+    copyDevModules: function(options) {
+          return new Promise((resolve, reject) => {
+              if(options.copyDevModules || ee['copy-dev-modules']){
+                const modules_lentgh = this.modulesToCopy.length;
+                const target         = `${this.project.root}/tmp/electron-build-tmp/node_modules/`;
+                const root           = `${this.project.root}/node_modules/`;
+
+                if(modules_lentgh > 0) {
+                    for (var i = 0; i < modules_lentgh; i++) {
+                        try{
+                             this.ui.writeLine('Copying ' + this.modulesToCopy[i] + ' from dev node_modules');
+                             fs.copySync(root + this.modulesToCopy[i], target + this.modulesToCopy[i]);
+                        } catch (err) {
+                             reject(err);
+                        }
+                    }
+                }
+             }
+             resolve();
+         });
+
+    },
+
+
     installDependency: function (installedDeps, name, version) {
         return new Promise((resolve, reject) => {
             const path = `${this.project.root}/tmp/electron-build-tmp`;
-
+       
             npmi({name, version, path}, (err) => {
                 if (err) {
                     this.ui.writeLine('');
@@ -221,17 +252,32 @@ module.exports = {
         });
     },
 
-    installDependencies: function () {
+    installDependencies: function (options) {
         return new Promise((resolve) => {
             const deps = [];
+            const ee = this.project.pkg['ember-electron'] || {};
 
             this.ui.writeLine(chalk.green('Installing production dependencies into Electron Build Package'));
 
             // Push all dependencies into an array for easier processing
             for (var name in this.project.pkg.dependencies) {
-                if (this.project.pkg.dependencies.hasOwnProperty(name)) {
-                    deps.push([name, this.project.pkg.dependencies[name]]);
+                // Check if we need to copy dev node_modules
+                if(options.copyDevModules || ee['copy-dev-modules']){
+                        // check if dependencie is added in dev dependencies
+                        if (this.project.pkg.devDependencies.hasOwnProperty(name)) {
+                                this.modulesToCopy.push(name);
+                        } else {
+                            // not in dev dependencies, adding to install
+                             if (this.project.pkg.dependencies.hasOwnProperty(name)) {
+                                 deps.push([name, this.project.pkg.dependencies[name]]);
+                            }
+                        }
+                } else {
+                          if (this.project.pkg.dependencies.hasOwnProperty(name)) {
+                                 deps.push([name, this.project.pkg.dependencies[name]]);
+                            }
                 }
+              
             }
 
             // Process the array in order
@@ -347,7 +393,8 @@ module.exports = {
                 prune: options.prune || ee.prune,
                 sign: options.sign || ee.sign,
                 'strict-ssl': options.strictSsl || ee['strict-ssl'],
-                'version-string': options.versionString || ee['version-string']
+                'version-string': options.versionString || ee['version-string'],
+                'copy-dev-modules': options.copyDevModules || ee['copy-dev-modules']
             };
 
             packager(packageOptions, (err) => {
@@ -367,8 +414,9 @@ module.exports = {
     run: function (options) {
         return this.build(options)
             .then(() => this.organize(options))
-            .then(() => this.installDependencies())
+            .then(() => this.installDependencies(options))
             .then(() => this.recompileDependencies(options))
+            .then(() => this.copyDevModules(options))
             .then(() => this.package(options))
             .then(() => this.cleanup());
     }


### PR DESCRIPTION
We check in installDependencies if node module from dependencies is inside devDependencies, after that we push it to array ( before in this point i would call copyDevModule to copy one module but because of recompiling native dependencies it was changed). 

After recompileDependencies we call copyDevModules to copy those modules.