### PR TITLE
Update electron-packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-string-replace": "^0.1.1",
     "chalk": "^1.1.0",
-    "electron-packager": "^6.0.0",
+    "electron-packager": "^7.0.0",
     "ember-cli-babel": "^5.1.5",
     "ember-inspector": "^1.9.5",
     "express": "^4.13.4",


### PR DESCRIPTION
> npm WARN deprecated electron-packager@6.0.2: Critical security bug fixed in v7.0.0 - read more at https://github.com/electron-userland/electron-packager/issues/333