### PR TITLE
fixes watcher throwing errors on linux in testing

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -9,17 +9,26 @@
 
     // Reload the page when anything in `dist` changes
     var fs = window.requireNode('fs');
+    var path = window.requireNode('path');
     var watch = function (sub) {
         var dirname = __dirname;
+        var isInTest = !!window.QUnit;
+
+        if (isInTest) {
+          // In tests, __dirname is `<project>/tmp/<broccoli-dist-path>/tests`.
+          // In normal `ember:electron` it's `<project>/dist`.
+          // To achieve the regular behavior in testing, go to parent dir, which contains `tests` and `assets`
+          dirname = path.join(dirname, '..');
+        }
 
         if (sub) {
-            dirname += sub;
+          dirname = path.join(dirname, sub);
         }
 
         fs.watch(dirname, {recursive: true}, function (e) {
-            window.location.reload()
+            window.location.reload();
         });
-    }
+    };
 
     fs.stat(__dirname, function (err, stat) {
         if (!err) {


### PR DESCRIPTION
fixes watcher path in testing

As explained in `#e-hearth`, there is currently a bug in testing, where `ember-electron` tries to add watchers on linux for `/assets` and `/tests`.
The problem is that it the `__dirname` path in testing is different compared to regular `ember electron` builds, which results in fs trying to add watchers to non existing paths. 
(`<project>/tmp/<broccoli-dist-path>/tests` vs `<project>/dist`).

~~This PR adds an additional check for test environment (by reading the [`TESTS_FILE_LOADED` var, added in testing](https://github.com/ember-cli/ember-cli/blob/87154e7975c6be13375bb7fed977a9f63ddccb19/lib/broccoli/tests-suffix.js#L4)), where it changes the dirname to the current parent dir.~~
Test environment check is done by checking for existence of `window.QUnit`.

Open questions:
- ~~is there a better way to detect if the current env is testing? TESTS_FILE_LOADED was added in Sep 17, 2015 and could break for older ember-cli versions~~
- i can't check if the unexpected test `__dirname` also occurs on osx (no modern.ie equivalent :( ), we should probably test it there before merging.