### PR TITLE
:bug: Handle getting multiple lines in CI

### DIFF
--- a/lib/commands/electron-test/runner-ci.js
+++ b/lib/commands/electron-test/runner-ci.js
@@ -10,22 +10,18 @@ function runElectron(electronPath, testsPath) {
     // Cleanup Electron output to be TAP (test anything protocol) compliant
     electron.stdout.on('data', function (data) {
         data = data.toString('utf8');
+        data.split('[qunit-logger] ').slice(1).forEach((line) => {
+            process.stdout.write(`${line}\n`);
 
-        if (data.indexOf('[qunit-logger]') > -1) {
-            data = data.replace('[qunit-logger] ', '');
-            data = data + '\n';
-
-            process.stdout.write(data);
-
-            if (data === '# done with errors') {
+            if (line === '# done with errors') {
                 hasErrors = true;
             }
 
-            if (data.indexOf('# done') > -1) {
+            if (line.indexOf('# done') > -1) {
                 electron.kill();
                 process.exit(hasErrors ? 1 : 0);
             }
-        }
+        });
     });
 }
 


### PR DESCRIPTION
Sometimes the CI runner can get multiple log statements at once resulting in output like this:

```
ok 1 Electron (CI) - JSCS - app.js # should pass jscs
ok 2 Electron (CI) - JSHint | app.js # should pass jshint
ok 3 Electron (CI) - JSCS - electron.js # should pass jscs
ok 4 Electron (CI) - JSHint | electron.js # should pass jshint
ok 5 Electron (CI) - JSCS - helpers/destroy-app.js # should pass jscs
ok 6 Electron (CI) - JSHint | helpers/destroy-app.js # should pass jshint
ok 7 Electron (CI) - JSCS - helpers/module-for-acceptance.js # should pass jscs
ok 8 Electron (CI) - JSHint | helpers/module-for-acceptance.js # should pass jshint
ok 9 Electron (CI) - JSCS - helpers/resolver.js # should pass jscs
ok 10 Electron (CI) - JSHint | helpers/resolver.js # should pass jshint
ok 11 Electron (CI) - JSCS - helpers/start-app.js # should pass jscs
ok 12 Electron (CI) - JSHint | helpers/start-app.js # should pass jshint
ok 13 Electron (CI) - JSCS - locales/en/translations.js # should pass jscs
ok 14 Electron (CI) - JSHint | locales/en/translations.js # should pass jshint
ok 15 Electron (CI) - JSCS - resolver.js # should pass jscs[qunit-logger] ok 16 - JSHint | resolver.js # should pass jshint
ok 16 Electron (CI) - JSCS - router.js # should pass jscs[qunit-logger] ok 18 - JSHint | router.js # should pass jshint[qunit-logger] ok 19 - JSCS - test-helper.js # should pass jscs[qunit-logger] ok 20 - JSHint | test-helper.js # should pass jshint[qunit-logger] # done
1..16
# tests 16
# pass  16
# skip  0
# fail  0
```

This is especially bad when the build fails because the `# done with errors` line won't be detected.

To fix this, I split the line on the `[qunit-logger] ` tag and process each log statement.