### PR TITLE
Spawn electron with a shell on Win32

### DIFF
--- a/lib/commands/electron.js
+++ b/lib/commands/electron.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const RSVP = require('rsvp');
 const debugServer = require('../helpers/debug-server');
 const getRemoteDebugSocketScript = require('../helpers/remote-debug-script');
+const os = require('os');
 
 const Promise = RSVP.Promise;
 
@@ -89,7 +90,8 @@ module.exports = {
             const electronCommand = findElectron(project);
             const child = spawn(electronCommand, ['.'], {
                 cwd: project.root,
-                stdio: 'inherit'
+                stdio: 'inherit',
+                shell: os.platform() === 'win32'
             });
 
             child.on('error', (error) => {


### PR DESCRIPTION
This pull request resolves a weird edge case I ran into while developing on my Windows machine. I had installed `electron-prebuilt` globally, and was getting an error when trying to run `ember electron`:

```
Error running the following command: Electron
```

I was getting this error despite the fact that I could run the `Electron` command just fine manually. After a bit of digging, I found [this](https://github.com/nodejs/node-v0.x-archive/issues/2318) long-standing node issue, which suggested using the `shell` option on the `spawn` command. Setting that flag resolved the issue for me.

After some more investigating, I figured out that part of the problem seemed to stem from using PowerShell instead of the vanilla Windows command prompt.

I'm not sure how important it is to resolve this issue, but I figured I would open a pull request since this might be confusing other users out there.