### PR TITLE
:bug: Stop importing reload in production

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ module.exports = {
             return;
         }
 
-        app.import({
-            development: 'vendor/electron/reload.js'
-        });
+        if (app.env === 'development') {
+            app.import('vendor/electron/reload.js');
+        }
+
         if (process.env.ELECTRON_TESTS_DEV) {
             app.import({
                 test: 'vendor/electron/browser-qunit-adapter.js'


### PR DESCRIPTION
`vendor/electron/reload.js` is being included in production builds which causes `Cannot find module 'devtron'` errors.

If you give an object to `app.import` and the environment you are building for isn't present in the object, it defaults to the development version of the asset (https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/ember-app.js#L1610). The ember-cli docs say to use an `if` to selectively import assets (https://ember-cli.com/user-guide/#environment-specific-assets), so that is what I have done here.