### PR TITLE
Fix app declaration

### DIFF
--- a/blueprints/ember-electron/files/electron.js
+++ b/blueprints/ember-electron/files/electron.js
@@ -3,7 +3,7 @@
 
 const electron             = require('electron');
 const path                 = require('path');
-const app, BrowserWindow   = electron.app;
+const app                  = electron.app;
 const BrowserWindow        = electron.BrowserWindow;
 const dirname              = __dirname || path.resolve(path.dirname());
 const emberAppLocation     = `file://${dirname}/dist/index.html`;


### PR DESCRIPTION
Fixes the following error in electron.js:
const app, BrowserWindow   = electron.app;
      ^^^
SyntaxError: Missing initializer in const declaration