### PR TITLE
:bug: Fix lookup of prebuilt package

### DIFF
--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -315,8 +315,8 @@ module.exports = {
       }
 
       const rebuild = require('electron-rebuild')
-      const prebuiltPackagePath = getElectronPackagePath(this.project.root)
-      const prebuiltPackage = (prebuiltPackagePath) ? require(path.join(prebuiltPackagePath, 'package.json')) : null
+      const prebuiltPackagePath = getElectronPackagePath(this.project)
+      const prebuiltPackage = (prebuiltPackagePath) ? require(path.join(prebuiltPackagePath, '../package.json')) : null
       const electronVersion = (prebuiltPackage) ? prebuiltPackage.version : undefined
       const target = `${this.project.root}/tmp/electron-build-tmp/node_modules`
       const ee = this.project.pkg['ember-electron'] || {}


### PR DESCRIPTION
The package command fails when it recompiles native dependencies.

There are 2 issues:
* `getElectronPackagePath` expects a project object not a path
* it looks for `package.json` in `electron-prebuilt`'s `dist` directory rather than its root

I've fixed these issues and packaging works for me again.