### PR TITLE
:bug: Fix tap reporter

### DIFF
--- a/app/electron/tap-qunit-adapter.js
+++ b/app/electron/tap-qunit-adapter.js
@@ -34,8 +34,10 @@
     QUnit.log((details) => {
       if (details.result !== true) {
         const actualTestCount = testCount + 1
-        log(`# ${JSON.stringify(details)}`)
         log(`not ok ${actualTestCount} - ${details.module} - ${details.name}`)
+        log('  ---')
+        log(`  ${JSON.stringify(details)}`)
+        log('  ...')
       }
     })
 

--- a/lib/commands/electron-test/reporter.js
+++ b/lib/commands/electron-test/reporter.js
@@ -21,15 +21,11 @@ util.inherits(CustomTapReporter, TapReporter)
 
 CustomTapReporter.prototype.report = function (prefix, data) {
   if (data.items && data.items.length > 0) {
-    try {
-      var details = JSON.parse(data.items[0].stack)
-      data.error = {
-        actual: details.actual,
-        expected: details.expected,
-        message: details.message
-      }
-    } catch (error) {
-      process.stderr.write(data.items[0].stack)
+    data.error = {
+      actual: data.items[0].actual,
+      expected: data.items[0].expected,
+      stack: data.items[0].source,
+      message: data.items[0].message
     }
   }
 


### PR DESCRIPTION
fixes #118

The tap qunit adapter, custom tap reporter and testem tap reporter were not speaking each other's language. This checkin fixes #118 and gets us good test failure output in CI mode. The change pretty much consists of outputting the diag information in a tap yaml block (even though it's JSON), and then pushing the right values to the right places for the testem reporter to find and output.