### PR TITLE
call stopProgress() in cleanup to reenable cursor after packaging

### DIFF
--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -358,6 +358,7 @@ module.exports = Command.extend({
 
   cleanup: function () {
     return new Promise((resolve, reject) => {
+      this.ui.stopProgress()
       fs.remove(`${this.project.root}/tmp/electron-build-tmp`, (err) => {
         if (err) {
           reject(err)

--- a/tests/unit/commands/package-test.js
+++ b/tests/unit/commands/package-test.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const sinon = require('sinon')
 const mockery = require('mockery')
 const RSVP = require('rsvp')
 const MockUI = require('ember-cli/tests/helpers/mock-ui')
@@ -130,6 +130,27 @@ describe('ember electron:package command', () => {
 
     return expect(command).to.be.rejected.then(() => {
       expect(tasks).to.deep.equal(['build'])
+    })
+  })
+
+  it('should call ui.startProgress() and ui.stopProgress()', () => {
+    const uiSpyStart = sinon.spy(commandOptions.ui, 'startProgress')
+    const uiSpyStop = sinon.spy(commandOptions.ui, 'stopProgress')
+    commandOptions.tasks = {
+      Build: function () {
+        return {
+          run: function (options) {
+            return RSVP.resolve()
+          }
+        }
+      }
+    }
+
+    let command = new CommandUnderTest(commandOptions).validateAndRun()
+
+    return expect(command).to.be.fulfilled.then(() => {
+      expect(uiSpyStart.calledOnce).to.equal(true)
+      expect(uiSpyStop.calledOnce).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
This PR delivers a fix for #133.

The fix is working, but I still think that someone else in the used packages does something bad as well, as removing the startProgress() did not fix the issue. Will try to investigate further.

I've tried to add a little test, I hope the way I did it is roughly compatible with the way you write tests over here.

Thanks for the encouragement, @felixrieseberg, that's how you get PRs :)