### PR TITLE
Prevent infinite loop within Command init()

### DIFF
--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -6,7 +6,7 @@ module.exports = Command.extend({
   init() {
     process.env.EMBER_CLI_ELECTRON = true;
 
-    if (this._super && this._super.init) {
+    if (this._super && this._super.init && this._super.init !== this.init) {
       this._super.init.apply(this, arguments);
     }
   },

--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -5,9 +5,6 @@ const Command = require('ember-cli/lib/models/command');
 module.exports = Command.extend({
   init() {
     process.env.EMBER_CLI_ELECTRON = true;
-
-    if (this._super && this._super.init && this._super.init !== this.init) {
-      this._super.init.apply(this, arguments);
-    }
+    this._super(...arguments);
   },
 });


### PR DESCRIPTION
While debugging a recent install of 2.beta, @anulman and I came across a strange loop within `-command.js`: