### PR TITLE
Remove Bower installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,13 @@ addons:
 cache:
   directories:
     - $HOME/.npm
-    - $HOME/.cache # includes bowers cache
+    - $HOME/.cache
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - bower --version
 
 install:
   - npm install
-  - bower install
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,7 @@ before_install:
   - "npm config set spin false"
 
 install:
-  - npm install -g bower
   - npm install
-  - bower install
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 ```


### PR DESCRIPTION
Ember no longer requires bower and this addon has no frontend dependencies relying on it so we can savely remove this step and speed up the CI builds a little.