### PR TITLE
Updated shims

### DIFF
--- a/blueprints/ember-electron/files/ember-electron/electron.js
+++ b/blueprints/ember-electron/files/ember-electron/electron.js
@@ -32,8 +32,6 @@ app.on('ready', function onReady() {
         height: 600
     });
 
-    delete mainWindow.module;
-
     // If you want to open up dev tools programmatically, call
     // mainWindow.openDevTools();
 

--- a/blueprints/ember-electron/files/tests/electron.js
+++ b/blueprints/ember-electron/files/tests/electron.js
@@ -20,8 +20,6 @@ app.on('ready', function onReady() {
         backgroundThrottling: false
     });
 
-    delete mainWindow.module;
-
     mainWindow.loadURL(testUrl);
 
     mainWindow.on('closed', function onClosed() {

--- a/index.js
+++ b/index.js
@@ -7,10 +7,9 @@ let path = require('path');
 function injectScript(scriptName) {
   let dirname = __dirname || path.resolve(path.dirname());
   let filePath = path.join(dirname, 'lib', 'resources', scriptName);
+  let fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
 
-  return `<script>\n${  fs.readFileSync(filePath, {
-    encoding: 'utf8',
-  })  }\n</script>`;
+  return `<script>\n${fileContent}</script>`;
 }
 
 module.exports = {
@@ -85,12 +84,14 @@ module.exports = {
   contentFor(type) {
     const { env: { EMBER_CLI_ELECTRON } } = process;
 
-    if (EMBER_CLI_ELECTRON && type === 'head') {
-      return injectScript('shim-head.js');
-    }
+    if (EMBER_CLI_ELECTRON) {
+      if (type === 'body-footer') {
+        return injectScript('shim-footer.js');
+      }
 
-    if (EMBER_CLI_ELECTRON && type === 'body-footer') {
-      return injectScript('shim-footer.js');
+      if (type === 'head') {
+        return injectScript('shim-head.js');
+      }
     }
   },
 };

--- a/lib/resources/shim-footer.js
+++ b/lib/resources/shim-footer.js
@@ -1,31 +1,25 @@
-/* eslint "prefer-spread": "off", "ember-suave/prefer-destructuring": "off" */
+// ember-electron
+((win) => {
+  const { requireNode, require: requireAMD } = win;
 
-(function() {
-  if (!window.ELECTRON) {
-    return;
-  }
-
-  // Restore Electron variables.
-  window.process = window.processNode;
-
-  // Redefine a global `require` function that can satisfy both
-  // Node and AMD module systems.
-  const requireAMD = window.require;
-  const requireNode = window.requireNode;
-
+  // Redefine a global `require` function that can satisfy both Node and AMD module systems.
   if (requireAMD) {
-    window.require = function() {
+    win.require = (...args) => {
       try {
-        return requireAMD.apply(null, arguments);
-      } catch(e) {
-        if (e.toString().includes('Error: Could not find module')) {
-          return requireNode.apply(null, arguments);
-        } else {
-          return console.error(e);
+        return requireAMD(...args);
+      } catch(error) {
+        if (error.toString().includes('Error: Could not find module')) {
+          return requireNode(...args);
         }
+
+        console.error(error);
       }
     };
   } else {
-    window.require = requireNode;
+    win.require = requireNode;
   }
-})();
+
+  // Restore others
+  win.process = win.processNode;
+  win.module = win.moduleNode;
+})(window);

--- a/lib/resources/shim-head.js
+++ b/lib/resources/shim-head.js
@@ -1,13 +1,14 @@
-(function() {
-  if (window && window.process && window.process.type) {
-    window.ELECTRON = true;
-  }
+// ember-electron
+((win) => {
+  win.ELECTRON = true;
 
-  window.requireNode = window.require;
-  window.moduleNode = window.module;
-  window.processNode = window.process;
+  // Store electrons node environment injections for later usage
+  win.moduleNode = win.module;
+  win.processNode = win.process;
+  win.requireNode = win.require;
 
-  delete window.process;
-  delete window.require;
-  delete window.module;
-})();
+  // Delete the originals so Ember is not confused
+  delete win.module;
+  delete win.process;
+  delete win.require;
+})(window);

--- a/node-tests/fixtures/project-with-test-config/tests/electron.js
+++ b/node-tests/fixtures/project-with-test-config/tests/electron.js
@@ -16,8 +16,6 @@ app.on('ready', function onReady() {
     height: 600,
   });
 
-  delete mainWindow.module;
-
   if (process.env.EMBER_ENV === 'test') {
     mainWindow.loadUrl(`file://${__dirname}/index.html`);
   } else {

--- a/tests/electron.js
+++ b/tests/electron.js
@@ -20,8 +20,6 @@ app.on('ready', function onReady() {
     backgroundThrottling: false,
   });
 
-  delete mainWindow.module;
-
   mainWindow.loadURL(testUrl);
 
   mainWindow.on('closed', function onClosed() {


### PR DESCRIPTION
The whole shims topic kept on nagging me, so here is a small, mostly cosmetic update.

* Modern JS syntax (supported since Chrome 45/46/47)
* Added a few comments to clear up where the injections come from and what they actually do

Changes to index.js:
* reading file in script injections separated in variable for readability
* collapsed conditional for injections (this was an artifact from earlier versions)

Changes to head:
* Use modern code style (arrow functions)
* Always export win.ELECTRON as the file is only injected in electron
* added comments
* window global is only called once

Changes to footer:
* Use modern code style (arrow functions, destructuring, rest params, spread)
* Cleaned up try/catch/if/else paths (no need for else if we return early)
* added comments