### PR TITLE
Removing ember-welcome-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "^2.11.0",
-    "ember-welcome-page": "^2.0.2",
     "eslint": "^3.16.1",
     "eslint-config-ember": "^0.3.0",
     "eslint-plugin-ember-suave": "^1.0.0",


### PR DESCRIPTION
If I understand correctly, [`ember-welcome-page`](https://github.com/ember-cli/ember-welcome-page) is not necessary/used by addons, so I think it should be removed from this addon's `package.json`.