### PR TITLE
Add electron-out to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ bower_components/
 tests/
 tmp/
 dist/
+electron-out/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Don't want to include it in release packages if it's present!