### PR TITLE
Replace path.resolve(path.dirname()) -> process.cwd()

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -16,7 +16,7 @@
    * @param sub directory
    */
   let watch = function(sub) {
-    let dirname = __dirname || path.resolve(path.dirname());
+    let dirname = __dirname || process.cwd();
     let isInTest = !!window.QUnit;
 
     if (isInTest) {
@@ -74,7 +74,7 @@
   };
 
   document.addEventListener('DOMContentLoaded', (/* e */) => {
-    let dirname = __dirname || path.resolve(path.dirname());
+    let dirname = __dirname || process.cwd();
 
     fs.stat(dirname, (err/* , stat */) => {
       if (!err) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let path = require('path');
 let { clone } = require('lodash/lang');
 
 function injectScript(scriptName) {
-  let dirname = __dirname || path.resolve(path.dirname());
+  let dirname = __dirname || process.cwd();
   let filePath = path.join(dirname, 'lib', 'resources', scriptName);
   let fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
 
@@ -38,7 +38,7 @@ module.exports = {
   },
 
   treeForVendor() {
-    let dirname = __dirname || path.resolve(path.dirname());
+    let dirname = __dirname || process.cwd();
 
     return path.join(dirname, 'app');
   },


### PR DESCRIPTION
This may really be just a cosmetic thing, but as was noted in #154, there appears to be some broken code regarding a work-around for missing `__dirname` (see also #56). It looks like there are several places where we have code like `__dirname || path.resolve(path.dirname())`.

As @pichfl noted, [`path.dirname()` throws `TypeError: Path must be a string. Received undefined`](https://github.com/nodejs/node/blob/98e54b0bd4854bdb3e2949d1b6b20d6777fb7cde/lib/path.js#L1345), so it shouldn't be called without arguments. Secondly, I'm pretty sure this is extraneous code to begin with since calling `path.resolve()` (no arguments) returns a string containing the CWD, which I think is the same as `path.resolve('.')` (which should be the same as `path.resolve(path.dirname(''))`).

The [node v4.x docs](https://nodejs.org/dist/latest-v4.x/docs/api/path.html#path_path_resolve_from_to) weren't particularly clear about this:
> Note: If the arguments to resolve have zero-length strings then the current working directory will be used instead of them.

but the [latest ones](https://nodejs.org/docs/latest/api/path.html) make this explicit:
> If no path segments are passed, path.resolve() will return the absolute path of the current working directory.

and a quick, manual test in the 4.x REPL suggest the behavior has not changed.

Is there any reason we wouldn't want to remove this extra (potentially typo-prone) call?