### PR TITLE
Watch `dist/ember` instead of `__dirname` in `reload.js` (to fix #182)

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -7,6 +7,10 @@
   // Reload the page when anything in `dist` changes
   let fs = window.requireNode('fs');
   let path = window.requireNode('path');
+  // Note: This path assumes we're running in development, but
+  // if app.env !== 'development' then this file shouldn't have been imported at all
+  // (see ../../index.js)
+  const emberDistDir = path.resolve('dist', 'ember');
 
   /**
    * @private
@@ -16,21 +20,21 @@
    * @param sub directory
    */
   let watch = function(sub) {
-    let dirname = __dirname || process.cwd();
     let isInTest = !!window.QUnit;
+    let dirToWatch = emberDistDir;
 
     if (isInTest) {
       // In tests, __dirname is `<project>/tmp/<broccoli-dist-path>/tests`.
       // In normal `ember:electron` it's `<project>/dist`.
       // To achieve the regular behavior in testing, go to parent dir, which contains `tests` and `assets`
-      dirname = path.join(dirname, '..');
+      dirToWatch = path.join(dirToWatch, '..');
     }
 
     if (sub) {
-      dirname = path.join(dirname, sub);
+      dirToWatch = path.join(dirToWatch, sub);
     }
 
-    fs.watch(dirname, { recursive: true }, () => window.location.reload());
+    fs.watch(dirToWatch, { recursive: true }, () => window.location.reload());
   };
 
   /**
@@ -74,9 +78,7 @@
   };
 
   document.addEventListener('DOMContentLoaded', (/* e */) => {
-    let dirname = __dirname || process.cwd();
-
-    fs.stat(dirname, (err/* , stat */) => {
+    fs.stat(emberDistDir, (err/* , stat */) => {
       if (!err) {
         watch();
 


### PR DESCRIPTION
It seems that [`reload.js` was attempting to use `__dirname`](https://github.com/felixrieseberg/ember-electron/blob/master/app/electron/reload.js#L19) to locate the front-end / ember app files, and somewhere along the way this stopped working (perhaps when switching to `electron-forge` or changing the structure of the `dist` output folder). (See #182) Although there may be a better solution than this, I just changed `reload.js` to use `path.resolve('dist', 'ember')` instead since this appears to do the trick.

If anyone has comments / feedback / alternatives / improvements feel free to let me know, and I'll be happy to update this with something better.