### PR TITLE
Work-around bad module path restrictions

### DIFF
--- a/app/electron/adjust-module-search-paths.js
+++ b/app/electron/adjust-module-search-paths.js
@@ -1,0 +1,50 @@
+// This function needs to be ES5 compatible since it may otherwise cause `uglify` to choke
+(function() {
+  // Exit immediately if we're not running in Electron
+  if (!window.ELECTRON) {
+    return;
+  }
+
+  // Electron restricts the node_modules search path such that only modules within
+  // its resources directory are allowed.
+  // https://github.com/electron/electron/blob/master/lib/common/reset-search-paths.js
+  //
+  // Unfortunately, during development a pre-built electron setup might be used and
+  // have its resources folder in some other folder than the app being served.
+  // To work around this we can add these paths back into the global list.
+  //
+  // Note: This should probably be handled upstream in electron-prebuilt-compiler
+
+  var fs = window.requireNode('fs');
+  var path = window.requireNode('path');
+  var module = window.requireNode('module');
+
+  var pathsToAdd = [];
+
+  // Check if we're running with resource root inside of a `electron-prebuilt-compile` dir.
+  // This should correspond to when running `ember electron`
+  var epcIndex = __dirname.indexOf('electron-prebuilt-compile');
+  if (epcIndex !== -1)
+    pathsToAdd.push(__dirname.slice(0, epcIndex));
+
+  // When running a packaged app, we have our modules in
+  // resources/app/node_modules
+  pathsToAdd.push(path.resolve(window.processNode.resourcesPath, 'app', 'node_modules'));
+
+  pathsToAdd.forEach(function(pathToAdd) {
+    // Note: sync version is used on purpose here since otherwise later calls to `require`
+    // may fail because they need to use these paths but this hasn't finished yet.
+    try {
+      var stats = fs.statSync(pathToAdd);
+      if (stats.isDirectory() && module.Module.globalPaths.indexOf(pathToAdd) === -1) {
+        module.Module.globalPaths.push(pathToAdd);
+      }
+    }
+    catch(e) {
+      // It's OK if any of these paths don't exist; we just won't add them.
+      // But if there's some other error we probably still want to know about it
+      if (e.code !== 'ENOENT')
+        throw e;
+    }
+  });
+}());

--- a/app/electron/adjust-module-search-paths.js
+++ b/app/electron/adjust-module-search-paths.js
@@ -1,19 +1,7 @@
-// This function needs to be ES5 compatible since it may otherwise cause `uglify` to choke
 (function() {
-  // Exit immediately if we're not running in Electron
   if (!window.ELECTRON) {
     return;
   }
-
-  // Electron restricts the node_modules search path such that only modules within
-  // its resources directory are allowed.
-  // https://github.com/electron/electron/blob/master/lib/common/reset-search-paths.js
-  //
-  // Unfortunately, during development a pre-built electron setup might be used and
-  // have its resources folder in some other folder than the app being served.
-  // To work around this we can add these paths back into the global list.
-  //
-  // Note: This should probably be handled upstream in electron-prebuilt-compiler
 
   var fs = window.requireNode('fs');
   var path = window.requireNode('path');
@@ -24,30 +12,28 @@
     path.resolve(window.processNode.resourcesPath, 'app', 'node_modules')
   ];
 
-  // Check if we're running with resource root inside of a `electron-prebuilt-compile` dir.
-  // This should correspond to when running `ember electron`
+  // n.b. if we are running in `electron-prebuilt-compile`,
+  // TODO @jacobq is this still necessary given window.processNoce.cwd() above?
+  //      - if so, plz explain what __dirname is, why you're slicing, etc
   var epcIndex = __dirname.indexOf('electron-prebuilt-compile');
-  if (epcIndex !== -1)
+  if (epcIndex !== -1) {
     pathsToAdd.push(__dirname.slice(0, epcIndex));
-
-  // When running a packaged app, we have our modules in
-  // resources/app/node_modules
-  pathsToAdd.push(path.resolve(window.processNode.resourcesPath, 'app', 'node_modules'));
+  }
 
   pathsToAdd.forEach(function(pathToAdd) {
-    // Note: sync version is used on purpose here since otherwise later calls to `require`
-    // may fail because they need to use these paths but this hasn't finished yet.
     try {
+      // n.b. use statSync to prevent race conditions
       var stats = fs.statSync(pathToAdd);
-      if (stats.isDirectory() && module.Module.globalPaths.indexOf(pathToAdd) === -1) {
-        module.Module.globalPaths.push(pathToAdd);
+
+      // TODO @jacobq explain why you are setting globalPaths vs paths
+      if (stats.isDirectory() && module.globalPaths.indexOf(pathToAdd) === -1) {
+        module.globalPaths.push(pathToAdd);
       }
-    }
-    catch(e) {
-      // It's OK if any of these paths don't exist; we just won't add them.
-      // But if there's some other error we probably still want to know about it
-      if (e.code !== 'ENOENT')
+    } catch(e) {
+      // n.b. ignore "dir does not exist" errors, else throw
+      if (e.code !== 'ENOENT') {
         throw e;
+      }
     }
   });
 }());

--- a/app/electron/adjust-module-search-paths.js
+++ b/app/electron/adjust-module-search-paths.js
@@ -19,7 +19,10 @@
   var path = window.requireNode('path');
   var module = window.requireNode('module');
 
-  var pathsToAdd = [];
+  var pathsToAdd = [
+    path.join(window.processNode.cwd(), 'node_modules'),
+    path.resolve(window.processNode.resourcesPath, 'app', 'node_modules')
+  ];
 
   // Check if we're running with resource root inside of a `electron-prebuilt-compile` dir.
   // This should correspond to when running `ember electron`

--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -7,9 +7,7 @@
   // Reload the page when anything in `dist` changes
   let fs = window.requireNode('fs');
   let path = window.requireNode('path');
-
   let rootDir = window.processNode.cwd();
-  let nodeModules = path.join(rootDir, 'node_modules');
 
   /**
    * @private
@@ -29,8 +27,7 @@
    * Install Devtron in the current window.
    */
   let installDevtron = function() {
-    let pathToDevtron = path.join(nodeModules, 'devtron');
-    let devtron = window.requireNode(pathToDevtron);
+    let devtron = window.requireNode('devtron');
 
     if (devtron) {
       devtron.install();
@@ -42,7 +39,7 @@
    * Install Ember-Inspector in the current window.
    */
   let installEmberInspector = function() {
-    let location = path.join(nodeModules, 'ember-inspector', 'dist', 'chrome');
+    let location = path.join(rootDir, 'node_modules', 'ember-inspector', 'dist', 'chrome');
 
     fs.lstat(location, (err, results) => {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ module.exports = {
     if (app.env === 'development') {
       app.import('vendor/electron/reload.js');
     }
+
+    app.import('vendor/electron/adjust-module-search-paths.js');
   },
 
   includedCommands() {

--- a/index.js
+++ b/index.js
@@ -17,17 +17,15 @@ module.exports = {
   name: 'ember-electron',
 
   included(app) {
+    if (process.env.EMBER_CLI_ELECTRON) {
+      app.import('vendor/electron/adjust-module-search-paths.js');
+
+      if (app.env === 'development') {
+        app.import('vendor/electron/reload.js');
+      }
+    }
+
     this._super.included(app);
-
-    if (!process.env.EMBER_CLI_ELECTRON) {
-      return;
-    }
-
-    if (app.env === 'development') {
-      app.import('vendor/electron/reload.js');
-    }
-
-    app.import('vendor/electron/adjust-module-search-paths.js');
   },
 
   includedCommands() {


### PR DESCRIPTION
There seems to be an [upstream problem](https://github.com/electron-userland/electron-prebuilt-compile/issues/23) (or "feature" -- haven't figure it out completely yet) that prevents front-end code from being able to find modules (i.e. call `require` without path). For example, as described in #175, when running `ember electron` the `devtron` module won't load using `require('devtron')` even though the module is present in `<project>/node_modules`. 

Hopefully something will be done to address this upstream (if that's indeed the cause of the this), but in the mean time this patch adds either the project root's `node_modules` folder (i.e. when running `ember electron`) or the one inside electron's resource folder under `app/node_modules`. Although I'm not sure if this is a complete or proper solution, it seems to work and may be useful to others. Comments / feedback welcome.