### PR TITLE
refactor(electron-start): build & cleanup to `electron-livereload` dir

### DIFF
--- a/lib/commands/electron.js
+++ b/lib/commands/electron.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const RSVP = require('rsvp');
+const fs = require('fs-extra');
+const quickTemp = require('quick-temp');
 
 const Command = require('./-command');
 const Logger = require('../utils/logger');
 const WatchedBuild = require('../utils/watched-build');
-const start = require('electron-forge/dist/api/start').default;
+const efStart = require('electron-forge/dist/api/start').default;
 
 const { Promise } = RSVP;
 
@@ -25,7 +27,7 @@ module.exports = Command.extend({
   }, {
     name: 'output-path',
     type: String,
-    default: 'dist/',
+    default: quickTemp.makeOrRemake(this, '-electron-livereload'),
     aliases: ['o'],
   }, {
     name: 'verbose',
@@ -37,44 +39,12 @@ module.exports = Command.extend({
   run(options) {
     let logger = new Logger(this);
 
+    process.on('exit', () => {
+      this._cleanup(options);
+    });
+
     return this._buildAndWatch(options, logger)
-      .then(() => {
-        logger.message('Starting Electron...');
-
-        return start({ appPath: options.outputPath });
-      })
-      .then((handle) => {
-        return new Promise((resolve/* , reject */) => {
-          handle.on('close', (code, signal) => {
-            if (options.verbose) {
-              logger.section([
-                'Electron closed',
-                `  - with code: ${code}`,
-                `  - with signal: ${signal}`,
-              ]);
-            }
-          });
-
-          handle.on('disconnect', () => {
-            if (options.verbose) {
-              logger.message('Electron disconnected.');
-            }
-          });
-
-          handle.on('error', (err) => {
-            logger.error(err);
-          });
-
-          handle.on('exit', (/* code, signal */) => {
-            logger.message('Electron exited.');
-            resolve();
-          });
-
-          handle.on('message', (message) => {
-            logger.message(message);
-          });
-        });
-      });
+      .then(() => this._startElectron(options, logger));
   },
 
   _buildAndWatch({ environment, outputPath }, logger = new Logger(this)) {
@@ -92,5 +62,45 @@ module.exports = Command.extend({
     logger.startProgress('Building');
 
     return watchedBuild;
+  },
+
+  _startElectron({ outputPath, verbose }, logger = new Logger(this)) {
+    logger.message('Starting Electron...');
+
+    return efStart({ appPath: outputPath })
+      .then((handle) => new Promise((resolve/* , reject */) => {
+        handle.on('close', (code, signal) => {
+          if (verbose) {
+            logger.section([
+              'Electron closed',
+              `  - with code: ${code}`,
+              `  - with signal: ${signal}`,
+            ]);
+          }
+        });
+
+        handle.on('disconnect', () => {
+          if (verbose) {
+            logger.message('Electron disconnected.');
+          }
+        });
+
+        handle.on('error', (err) => {
+          logger.error(err);
+        });
+
+        handle.on('exit', (/* code, signal */) => {
+          logger.message('Electron exited.');
+          resolve();
+        });
+
+        handle.on('message', (message) => {
+          logger.message(message);
+        });
+      }));
+  },
+
+  _cleanup({ outputPath }) {
+    return fs.removeSync(outputPath);
   },
 });


### PR DESCRIPTION
Rationale: let's not overwrite `dist` with unfamiliar build artifacts that may get packaged up and deployed somewhere by unwitting scripts.

Probably best to land this after #188.