### PR TITLE
Fix module load paths

### DIFF
--- a/blueprints/ember-electron/index.js
+++ b/blueprints/ember-electron/index.js
@@ -65,7 +65,7 @@ class EmberElectronBlueprint extends Blueprint {
       // Production dependencies
       save: true,
       verbose: true,
-      packages: ['electron-protocol-serve@1.1.0', ...deps]
+      packages: ['electron-protocol-serve@^1.3.0', ...deps]
     }));
   }
 

--- a/ember-electron/lib/helper.js
+++ b/ember-electron/lib/helper.js
@@ -1,3 +1,3 @@
 module.exports = function() {
-  return;
+  return 'helper';
 };

--- a/lib/resources/shim-head.js
+++ b/lib/resources/shim-head.js
@@ -2,6 +2,28 @@
 ((win) => {
   win.ELECTRON = true;
 
+  // On linux the renderer process doesn't inherit the main process'
+  // environment, so we need to fall back to using the remote module.
+  var serveIndex = process.env.ELECTRON_PROTOCOL_SERVE_INDEX || require('electron').remote.process.env.ELECTRON_PROTOCOL_SERVE_INDEX;
+  if (serveIndex && window.location.protocol !== 'file:') {
+    // Using electron-protocol-serve to load index.html via a 'serve:' URL
+    // prevents electron's renderer/init.js from setting the module search
+    // paths correctly. So this is basically a copy of that code, but using an
+    // environment variable set by electron-protocol-serve containing the
+    // filesystem path to index.html instead of window.location.
+    var path = require('path');
+    var Module = require('module');
+
+    global.__filename = path.normalize(serveIndex);
+    global.__dirname = path.dirname(serveIndex);
+
+    // Set module's filename so relative require can work as expected.
+    module.filename = global.__filename;
+
+    // Also search for module under the html file.
+    module.paths = module.paths.concat(Module._nodeModulePaths(global.__dirname));
+  }
+
   // Store electrons node environment injections for later usage
   win.moduleNode = win.module;
   win.processNode = win.process;

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "broccoli-string-replace": "^0.1.1",
     "chalk": "^1.1.0",
     "electron-forge": "^2.8.0",
-    "electron-protocol-serve": "^1.1.0",
+    "electron-protocol-serve": "^1.3.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.1.6",
     "ember-inspector": "2.0.4",

--- a/tests/unit/end-to-end-test.js
+++ b/tests/unit/end-to-end-test.js
@@ -14,3 +14,9 @@ test('node modules are accessible', function(assert) {
   let { fill } = requireNode('lodash/array');
   assert.deepEqual(fill([0, 0, 0], 1), [1, 1, 1]);
 });
+
+test('local modules are accessible', function(assert) {
+  // ../../ because we are running out of ember/tests/index.html
+  let helper = requireNode('../../lib/helper.js');
+  assert.equal(helper(), 'helper');
+});


### PR DESCRIPTION
This fixes #175 (which was actually an inability to require *any* dependencies). The problem was that we switched over to using a custom 'serve://' protocol to load index.html via electron-protocol-serve, but when loading index.html via a non-file protocol, electron's renderer/init.js doesn't know where it is in the filesystem, so it can't set up the node module search paths correctly.

So, this change adds some code to our shim-header.js to check to see if we were loaded by a non-file protocol, and if electron-protocol-serve set the ELECTRON_PROTOCOL_SERVE_INDEX environment variable giving us the path to index.html, and if so, runs some copypasta'ed code from electron's renderer/index.js to set up the module search paths correctly.

This also fixes #192