### PR TITLE
fix(blueprint): Unpin devtron & electron-protocol versions

### DIFF
--- a/blueprints/ember-electron/index.js
+++ b/blueprints/ember-electron/index.js
@@ -40,12 +40,12 @@ module.exports = class EmberElectronBlueprint extends Blueprint {
       .then(() => npmInstall.run({
         saveDev: true,
         verbose: false,
-        packages: ['devtron@1.4.0'],
+        packages: ['devtron@^1.4.0'],
       }))
       .then(() => this.taskFor('npm-install').run({
         save: true,
         verbose: false,
-        packages: ['electron-protocol-serve@1.1.0'],
+        packages: ['electron-protocol-serve@^1.3.0'],
       }))
       .then(() => logger.message('Installed electron build tools'));
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "broccoli-string-replace": "^0.1.1",
     "chalk": "^1.1.0",
     "electron-forge": "^2.8.0",
-    "electron-protocol-serve": "^1.1.0",
+    "electron-protocol-serve": "^1.3.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.1.6",
     "ember-inspector": "2.0.4",


### PR DESCRIPTION
Although I think this is only a problem when running the blueprint (e.g. not if re-running `npm install` later) it still looks like a mistake that we ought to correct.

BTW, is there a reason we don't list `devtron` in `package.json`'s `dependencies`? It is required to use all of the features of `ember-electron`. I know we add it with the blueprint, but if someone, for example (and this may be a bogus use case), was inspecting our `package.json` to determine our dependencies such as to check for modules using restrictive licenses, then they could get mislead.