### PR TITLE
Generate appropriate .eslintrc.js files in the blueprint

### DIFF
--- a/blueprints/ember-electron/files/ember-electron/.eslintrc.js
+++ b/blueprints/ember-electron/files/ember-electron/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    node: true
+  }
+};

--- a/blueprints/ember-electron/files/tests/ember-electron/.eslintrc.js
+++ b/blueprints/ember-electron/files/tests/ember-electron/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    node: true
+  }
+};


### PR DESCRIPTION
This is of course a very straightforward approach.

We could extend this in the future to generate the appropriate rc file depending on the linter installed but given that Ember CLI and basically everybody else as well is moving to ESLint we should be fine.