### PR TITLE
fix(reload): Added missing parentheses for dirname expression

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -81,7 +81,7 @@ function setupLivereload() {
   };
 
   document.addEventListener('DOMContentLoaded', (/* e */) => {
-    let dirname = __dirname || (process && (process || {}).cwd) ? process.cwd() : null;
+    let dirname = __dirname || ((process && (process || {}).cwd) ? process.cwd() : null);
 
     if (!dirname) {
       return;


### PR DESCRIPTION
Should fix regression described in [this comment](https://github.com/felixrieseberg/ember-electron/commit/3096252720efdc7d87fed15902b8f6a3b7c77c0a#commitcomment-21719560)