### PR TITLE
Update index.js with fix for npmTask invocation

### DIFF
--- a/blueprints/ember-electron/index.js
+++ b/blueprints/ember-electron/index.js
@@ -61,7 +61,7 @@ module.exports = class EmberElectronBlueprint extends Blueprint {
       outDir: 'electron-out',
     })
       .then(() => npmInstall.run({
-        saveDev: true,
+        'save-dev': true,
         verbose: false,
         packages: ['devtron@^1.4.0'],
       }))


### PR DESCRIPTION
Re #231 

Running `npmInstall` without `save` or `save-dev` in options runs `yarn install` instead, which does no longer accept packages as params. Ember CLI should throw / warn here.