### PR TITLE
Fix ember electron:test -s

### DIFF
--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -50,12 +50,6 @@ class Builder extends BaseBuilder {
     return ret;
   }
 
-  cleanup() {
-    this._unsymlinkModules();
-
-    return super.cleanup();
-  }
-
   _unsymlinkModules() {
     if (!this.symlinkNodeModules) {
       return;

--- a/node-tests/unit/models/builder-test.js
+++ b/node-tests/unit/models/builder-test.js
@@ -121,21 +121,4 @@ describe('Builder model', () => {
       expect(fs.existsSync(path.join(outputPath, 'node_modules'))).to.be.ok;
     });
   });
-
-  describe('cleanup', () => {
-    it('works with no node_modules symlink', () => {
-      let builder = new Builder({ project, outputPath });
-      builder.copyToOutputPath();
-      builder.cleanup();
-      expect(fs.existsSync(path.join(outputPath, 'build'))).to.not.be.ok;
-    });
-
-    it('works with a node_modules symlink', () => {
-      let builder = new Builder({ project, outputPath, symlinkNodeModules: true });
-      builder.copyToOutputPath();
-      builder.cleanup();
-      expect(fs.existsSync(path.join(outputPath, 'build'))).to.not.be.ok;
-      expect(fs.existsSync(path.join(outputPath, 'node_modules'))).to.not.be.ok;
-    });
-  });
 });

--- a/test-runner.js
+++ b/test-runner.js
@@ -31,7 +31,6 @@ if (require.main === module) {
   let url = require('url');
   let fileUrl = require('file-url');
   let treeKill = require('tree-kill');
-  let symlinkOrCopySync = require('symlink-or-copy').sync;
   let { start: efStart } = require('electron-forge');
 
   let [, , buildDir, baseUrl, testPageUrl, id] = process.argv;
@@ -78,17 +77,6 @@ if (require.main === module) {
   // the fact that '&' is a special shell character. So we do our own cheesy
   // workaround.
   testUrl = testUrl.replace(/&/g, '__amp__');
-
-  // Symlink
-  // Todo: The source sucks. We need to fix this.
-  const source = path.join(process.cwd(), 'node_modules');
-  const target = path.join(buildDir, 'node_modules');
-
-  symlinkOrCopySync(source, target);
-
-  process.on('exit', () => {
-    fs.unlinkSync(target);
-  });
 
   // Start electron
   efStart({ appPath: buildDir, dir: buildDir, args: [testUrl] }).then(({ pid }) => {


### PR DESCRIPTION
I forgot to manually test this command since it would be pretty difficult to acceptance test, and it was broken :( The problem was that when running ember electron:test, the cleanup method of the builder is called before we run the tests, and it was deleting the node_modules symlink, and relying on the test-runner script to re-create it. But the whole point of this change was that when running ember electron:test -s, we leave the symlink in place while running the tests, so the test-runner was failing because the symlink already existed.

We don't need to delete the symlink in the builder's cleanup method -- it's not doing any harm, so we just leave it in the build output and don't mess with it in the test-runner script at all.

Also, hurray for bugfixes that involve only deleting code! :1st_place_medal: 