### PR TITLE
Support debugging the main process (and other cli args)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,20 +3,14 @@ platform:
 environment:
   nodejs_version: "6"
 cache:
-- '%LOCALAPPDATA%\Yarn'
-- '%USERPROFILE%\.electron'
+  - '%LOCALAPPDATA%\Yarn'
+  - '%USERPROFILE%\.electron'
 
 install:
-- choco install handle
-# We need at least 0.23.2 for the optional dependencies fix, otherwise
-# electron-forge fails to install. This can be removed when appveyor updates
-# their build image to a new enough yarn version. choco upgrade yarn also
-# installs nodejs, so comment out the Install-Product step for now to save time
-#- ps: Install-Product node $env:nodejs_version $env:platform
-- choco upgrade yarn --version 0.23.2
-- yarn
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - yarn
 
 test_script:
-- yarn test
+  - yarn test
 
 build: off

--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -12,6 +12,26 @@ If you're running a later version of Electron, you will notice that ember-electr
 
 
 
+## Debugging the Main Process
+
+There are a variety of methods of debugging the main process. If you're on Electron 1.7.2 or newer, using the `--inspect`/`inspect-brk` flags is by far the best. You can read up on other methods [here](https://electron.atom.io/docs/tutorial/debugging-main-process/). Regardless of which method you use, you'll need to pass extra command-line options to Electron when launching. This can be done via the following syntax:
+
+```
+$ ember electron <ember electron args> --- <args to pass to Electron>
+```
+
+for example:
+
+```
+$ ember electron --- --inspect-brk
+```
+
+or:
+
+```
+$ ember electron --environment=production --- --debug-brk=5858
+```
+
 ## Conflict between Ember and Electron: require()
 
 Both Ember Cli and Node.js use `require()`. Without ember-electron, Ember will start and overwrite Node's `require()` method, meaning that you're stuck without crucial tools such as `require('electron')`.

--- a/lib/commands/electron.js
+++ b/lib/commands/electron.js
@@ -13,7 +13,7 @@ const { Promise } = RSVP;
 
 module.exports = Command.extend({
   name: 'electron',
-  description: 'Builds your app and launches Electron',
+  description: 'Builds your app and launches Electron. You can pass extra flags (e.g. --inspect-brk) to Electron by putting them after `---`',
 
   availableOptions: [{
     name: 'watcher',
@@ -70,11 +70,20 @@ module.exports = Command.extend({
   },
 
   _startElectron({ outputPath, verbose }, logger = new Logger(this)) {
-    logger.message('Starting Electron...');
+    const argv = this._getArgv();
+
+    let electronArgs = [];
+    let separatorIndex = argv.indexOf('---');
+    if (separatorIndex !== -1) {
+      electronArgs = argv.slice(separatorIndex + 1);
+      logger.message(`Starting Electron with args '${electronArgs.join(' ')}'...`);
+    } else {
+      logger.message('Starting Electron...');
+    }
 
     outputPath = path.resolve(outputPath);
 
-    return efStart({ appPath: outputPath, dir: outputPath })
+    return efStart({ appPath: outputPath, dir: outputPath, args: electronArgs })
       .then((handle) => new Promise((resolve/* , reject */) => {
         handle.on('close', (code, signal) => {
           if (verbose) {
@@ -105,5 +114,10 @@ module.exports = Command.extend({
           logger.message(message);
         });
       }));
+  },
+
+  // For test instrumentation
+  _getArgv() {
+    return process.argv;
   },
 });

--- a/node-tests/helpers/mocks/ef-start.js
+++ b/node-tests/helpers/mocks/ef-start.js
@@ -8,7 +8,7 @@ class MockElectronForgeStart {
   }
 
   default() {
-    this.calls.push({ arguments });
+    this.calls.push(arguments);
 
     return new Promise((resolve) => {
       resolve(this.handle);


### PR DESCRIPTION
Allow passing arguments from the command-line of ember:electron through to electron-forge to pass to Electron. This is most useful for passing debugger flags, but could be used for anything.