### PR TITLE
Fix node_modules symlink again

### DIFF
--- a/lib/models/assembler.js
+++ b/lib/models/assembler.js
@@ -10,6 +10,7 @@ const CoreObject = require('core-object');
 const SilentError = require('silent-error');
 const chalk = require('chalk');
 
+const rimraf = require('rimraf').sync;
 const Sync = require('tree-sync');
 
 /**
@@ -155,6 +156,15 @@ class Assembler extends CoreObject {
     let sync = this._sync;
     if (sync === undefined) {
       this._sync = sync = new Sync(inputPath, path.resolve(this.outputPath));
+    }
+
+    // Make sure there's isn't a symlinked node_modules from an ember electron
+    // command, or sync'ing will traverse into it and delete folders out of our
+    // project's node_modules.
+    const modules = path.join(outputPath, 'node_modules');
+    if (outputPath && fs.existsSync(modules)) {
+      // Will unlink if it's a symlink or recursively delete if not
+      rimraf(modules);
     }
 
     let changes = sync.sync();

--- a/lib/models/builder.js
+++ b/lib/models/builder.js
@@ -51,14 +51,10 @@ class Builder extends BaseBuilder {
   }
 
   _unsymlinkModules() {
-    if (!this.symlinkNodeModules) {
-      return;
-    }
-
     const { outputPath } = this;
     const modules = path.join(outputPath, 'node_modules');
 
-    if (outputPath && fs.existsSync(modules)) {
+    if (fs.existsSync(modules)) {
       // Will unlink if it's a symlink or recursively delete if not
       rimraf(modules);
     }

--- a/node-tests/integration/models/assembler-test.js
+++ b/node-tests/integration/models/assembler-test.js
@@ -2,8 +2,15 @@
 
 const path = require('path');
 const tmp = require('tmp');
-const { copySync, readFileSync } = require('fs-extra');
+const {
+  copySync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} = require('fs-extra');
 const walkSync = require('walk-sync');
+const symlinkOrCopySync = require('symlink-or-copy').sync;
 const MockUI = require('console-ui/mock');
 const MockProject = require('../../helpers/mocks/project');
 const expect = require('../../helpers/expect');
@@ -25,22 +32,26 @@ describe('Assembler model', () => {
     },
   };
 
-  function assemble(projectPath, { platform } = {}) {
-    let { name: tmpRoot } = tmp.dirSync();
-    let tmpDir = path.join(tmpRoot, 'project');
-    copySync(projectPath, tmpDir);
-    process.chdir(tmpDir);
-
+  function assembleInto(outputPath, { platform } = {}) {
     let ui = new MockUI();
     assembler = new Assembler({
       ui,
       project: new MockProject({ ui, pkg }),
       platform,
       emberBuildPath,
-      outputPath: path.join(tmpRoot, 'output'),
+      outputPath,
     });
 
     return assembler.assemble();
+  }
+
+  function assemble(projectPath, options) {
+    let { name: tmpRoot } = tmp.dirSync();
+    let tmpDir = path.join(tmpRoot, 'project');
+    copySync(projectPath, tmpDir);
+    process.chdir(tmpDir);
+
+    return assembleInto(path.join(tmpRoot, 'output'), options);
   }
 
   beforeEach(() => {
@@ -85,6 +96,38 @@ describe('Assembler model', () => {
     return assemble(fixturePath('project-resources'), { platform }).then(({ directory }) => {
       let filePath = path.join(directory, 'ember-electron', 'resources', 'platform.txt');
       expect(readFileSync(filePath).toString().trim()).to.equal(platform);
+    });
+  });
+
+  it('removes node_modules directory from the output directory before syncing', () => {
+    return assemble(fixturePath('project-resources')).then(({ directory }) => {
+      let nodeModulesPath = path.join(directory, 'node_modules');
+      mkdirSync(nodeModulesPath);
+      writeFileSync(path.join(nodeModulesPath, 'foo'), 'blah');
+
+      return assembleInto(directory);
+    }).then(({ directory }) => {
+      expect(existsSync(path.join(directory, 'node_modules'))).to.be.false;
+    });
+  });
+
+  it('removes node_modules symlink from the output directory before syncing', () => {
+    // Create a directory that we can make the target of the node_modules
+    // symlink so we can make sure syncing doesn't follow the symlink and delete
+    // the contents.
+    let { name: tmpDir } = tmp.dirSync();
+    let modulePath = path.join(tmpDir, 'some-module');
+    let filePath = path.join(modulePath, 'package.json');
+    mkdirSync(modulePath);
+    writeFileSync(filePath, '{}');
+
+    return assemble(fixturePath('project-resources')).then(({ directory }) => {
+      symlinkOrCopySync(tmpDir, path.join(directory, 'node_modules'));
+
+      return assembleInto(directory);
+    }).then(({ directory }) => {
+      expect(existsSync(path.join(directory, 'node_modules'))).to.be.false;
+      expect(existsSync(filePath)).to.be.true;
     });
   });
 });

--- a/node-tests/unit/models/builder-test.js
+++ b/node-tests/unit/models/builder-test.js
@@ -120,5 +120,14 @@ describe('Builder model', () => {
       builder.copyToOutputPath();
       expect(fs.existsSync(path.join(outputPath, 'node_modules'))).to.be.ok;
     });
+
+    it('manages the node_modules symlink across multiple calls with symlinkNodeModules changing', () => {
+      let builder = new Builder({ project, outputPath, symlinkNodeModules: true });
+      builder.copyToOutputPath();
+      builder = new Builder({ project, outputPath });
+      builder.copyToOutputPath();
+      expect(fs.existsSync(path.join(outputPath, 'node_modules'))).to.not.be.ok;
+      expect(fs.existsSync(path.join(project.root, 'node_modules'))).to.be.ok;
+    });
   });
 });


### PR DESCRIPTION
Fix a couple more cases where we can delete content out of the root project's node_modules:

1. Build with symlinking turned on (i.e. run ember electron) and then build with it turned off (e.g. run ember build)
2. Build with symlinking turned on (i.e. run ember electron) and then assemble (i.e. ember electron:assemble)