### PR TITLE
fix(package-task): ensure tmp dir is world-indexable

### DIFF
--- a/lib/tasks/package.js
+++ b/lib/tasks/package.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const childProcess = require('child_process');
 const { resolve } = require('rsvp');
 const quickTemp = require('quick-temp');
 const Task = require('ember-cli/lib/models/task');
@@ -25,6 +26,11 @@ class PackageTask extends Task {
     } else {
       // Assemble the project and pass to forge
       projectPath = quickTemp.makeOrRemake(this, '-tmpPath');
+
+      if (process.platform !== 'win32') {
+        childProcess.execSync(`chmod a+x ${projectPath}`);
+      }
+
       options.outputPath = projectPath;
       let assembleTask = new AssembleTask({ ui, analytics, project });
       assemblePromise = assembleTask.run(options);


### PR DESCRIPTION
On linux, `ember electron:package` (and everything consuming the package task) would create packages readable only by current user (perms `700`).

When installing a `make`d package, the 700 perms would be applied to the installed `resources/app` directory.

After some sleuthing with @malept & @CSstefan, we discovered this was due to e-electron's tmp packaging.

This PR ensures the tmp dir is world-indexable, which subsequently lets any user of a machine run an installed package per electron / forge expectations.

Possible downsides include "this is a feature not a bug". If this is the case, I believe we should read a configurable perms integer from somewhere, otherwise defaulting to `711`.

Note that this PR uses `childProcess.execSync` vs. `fs.chmod`; standard perms on Ember tmp dirs seem to throw when chmod'ing that dir programmatically (vs. simulating user action).

Quick review + release would be very much appreciated.