### PR TITLE
Fix live-reload

### DIFF
--- a/app/electron/reload.js
+++ b/app/electron/reload.js
@@ -1,5 +1,5 @@
 function setupLivereload() {
-  const process = window ? window.process : null;
+  const process = window ? window.processNode : null;
 
   // Exit immediately if we're not running in Electron
   if (!window.ELECTRON || (process && process.env && process.env.DO_NOT_SETUP_LIVERELOAD)) {


### PR DESCRIPTION
I installed fresh version of ember-electron and live-reload didn't work. I found out that `window.process` is undefined and `window.processNode` should be used instead.

Maybe there can be more bugs like this?