### PR TITLE
Fix the backgroundThrottling option for tests

### DIFF
--- a/ember-electron/test-main.js
+++ b/ember-electron/test-main.js
@@ -46,7 +46,9 @@ app.on('ready', function onReady() {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
-    backgroundThrottling: false,
+    webPreferences: {
+      backgroundThrottling: false,
+    },
   });
 
   delete mainWindow.module;


### PR DESCRIPTION
The `backgroundThrottling` option needs to be part of `webPreferences`: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions