### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ before_install:
   # We need at least 0.23.3 for the optional dependencies fix, otherwise
   # electron-forge fails to install. This can be removed when travis updates
   # their build image to a new enough yarn version.
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.23.3
-
-before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn config set no-progress
 


### PR DESCRIPTION
Apparently travis only supports one before_install key, and ignores all but the last, so our yarn upgrade was not happening.