### PR TITLE
chore(deps): upgrade electron-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "capture-exit": "^1.2.0",
     "chalk": "^1.1.0",
     "core-object": "^3.1.0",
-    "electron-forge": "~3.1.1",
+    "electron-forge": "~4.0.0",
     "electron-protocol-serve": "^1.3.0",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^1.1.6",


### PR DESCRIPTION
Upgrade electron-forge to `~4.0.0`, to incorporate upstream fixes re npm pruning bugs