### PR TITLE
Ember-Engines load order patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
       "ember": ">=2.3.0"
     },
     "after": [
-      "ember-cli-sri"
+      "ember-cli-sri",
+      "ember-engines"
     ]
   },
   "config": {


### PR DESCRIPTION
I noticed that `ember-electron` is _almost_ compatible with [engines](https://github.com/ember-engines/ember-engines) out of the box. The one troublesome spot is that `ember-engines` does some extra stuff in its `postprocessTree` hook (namely, generating an asset manifest) that relies on the Ember app existing at the tree root. Unfortunately, `ember-electron` happens to run first (thanks, alphabet!) and put the app into an `ember` subdirectory, and causes the manifest generation step to go awry.

Short version: this PR ensures that `ember-engines` does its thing first. Easy one-liner.

I do wonder if this is something that could be handled in `ember-asset-loader` long-term, but for now, this ought to make things a bit saner.