### PR TITLE
Update Electron Forge to 5.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chalk": "^1.1.0",
     "console-ui": "^1.0.3",
     "core-object": "^3.1.0",
-    "electron-forge": "~4.1.1",
+    "electron-forge": "~5.0.0",
     "electron-protocol-serve": "^1.3.0",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^1.1.6",


### PR DESCRIPTION
Since 4.1.x:

* Config for electron-rebuild (thanks to @bendemboski)
* `electron-wix-msi` support
* Snapcraft support, both making and publishing to the Snap Store

The major version bump has to do with the third party publisher API and should not affect ember-electron.