### PR TITLE
Fix for testing against electron 3 on windows

### DIFF
--- a/blueprints/ember-electron/index.js
+++ b/blueprints/ember-electron/index.js
@@ -66,18 +66,10 @@ module.exports = class EmberElectronBlueprint extends Blueprint {
 
     logger.startProgress('Installing electron build tools');
 
-    return npmInstall.run({
-        // FIXME: Something seems to break in Windows with electron v3.0.0
-        // This is a hack to make electron-forge install electron 2.x instead of 'latest' (3.x) into the project
-        // See https://github.com/electron-userland/electron-forge/blob/5.x/src/api/import.js#L179
-        save: true,
-        verbose: false,
-        packages: ['electron@2.0.7'],
-      })
-      .then(() => efImport({
+    return efImport({
         updateScripts: false,
         outDir: 'electron-out',
-      }))
+      })
       .then(() => npmInstall.run({
         'save-dev': true,
         verbose: false,

--- a/lib/test-support/test-main.js
+++ b/lib/test-support/test-main.js
@@ -9,7 +9,7 @@ let mainWindow = null;
 // The testUrl is a file: url pointing to our index.html, with some query
 // params we need to preserve for testem. So we need to register our ember
 // protocol accordingly.
-let [, , indexUrl, testemUrl] = process.argv;
+let [, , , indexUrl, testemUrl] = process.argv;
 // Undo workaround for windows (see test-runner.js for explanation)
 indexUrl = indexUrl.replace(/__amp__/g, '&');
 let {

--- a/lib/test-support/test-runner.js
+++ b/lib/test-support/test-runner.js
@@ -54,7 +54,15 @@ if (require.main === module) {
   testUrl = testUrl.replace(/&/g, '__amp__');
 
   // Start electron
-  efStart({ appPath: buildDir, dir: buildDir, args: [testUrl, testemUrl] }).then(({ pid }) => {
+  efStart({
+    appPath: buildDir,
+    dir: buildDir,
+    args: [
+      '--', // needed because https://github.com/electron/electron/pull/13039
+      testUrl,
+      testemUrl,
+    ],
+  }).then(({ pid }) => {
     // Clean up when we're killed
     process.on('SIGTERM', () => {
       treeKill(pid);


### PR DESCRIPTION
https://github.com/electron/electron/pull/13039 caused our tests to fail on windows because we pass URL arguments. So, we need to add a '--' to the arguments to work around the issue.